### PR TITLE
Update documentation pipeline deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ backrefs==5.8
     # via mkdocs-material
 bracex==2.5.post1
     # via wcmatch
-certifi==2025.4.26
+certifi==2025.6.15
     # via requests
 charset-normalizer==3.4.2
     # via requests
@@ -22,7 +22,7 @@ jinja2==3.1.6
     # via
     #   mkdocs
     #   mkdocs-material
-markdown==3.8
+markdown==3.8.1
     # via
     #   mkdocs
     #   mkdocs-material
@@ -76,7 +76,7 @@ requests==2.32.4
     # via mkdocs-material
 six==1.17.0
     # via python-dateutil
-urllib3==2.4.0
+urllib3==2.5.0
     # via requests
 watchdog==6.0.0
     # via mkdocs


### PR DESCRIPTION
Fixes #10.

## Summary by Sourcery

Update documentation pipeline dependencies and extend Dependabot to weekly pip dependency checks

Enhancements:
- Bump certifi to 2025.6.15, markdown to 3.8.1, and urllib3 to 2.5.0 in requirements.txt

CI:
- Add a pip package-ecosystem entry to Dependabot configuration for weekly updates