### PR TITLE
Include the highlighting theme in the pipeline.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,6 +38,7 @@ jobs:
             --toc-depth 2
             --chunk-template "%i.html"
             --template docs/template.html
+            --highlight-style docs/solarizeddark.theme
             --output "site"
             docs/docs.md
 


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Add the solarized dark syntax highlighting theme to the documentation generation command in the GitHub Actions workflow.