### PR TITLE
Go bolder

### DIFF
--- a/docs/template.html
+++ b/docs/template.html
@@ -18,7 +18,7 @@ $if(description-meta)$
 $endif$
   <title>$pagetitle$</title>
   <link rel="preconnect" href="https://fonts.bunny.net">
-  <link href="https://fonts.bunny.net/css?family=open-sans:400,400i,600,600i" type="text/css" rel="stylesheet">
+  <link href="https://fonts.bunny.net/css?family=open-sans:400,400i,800,800i" type="text/css" rel="stylesheet">
   <style type="text/css">
     $styles.css()$
   </style>


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Adjust docs HTML template to load Open Sans with 800/800i weights instead of 600/600i for stronger emphasis styling.