### PR TITLE
Add a colophon and granular font weights

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -157,3 +157,15 @@ tasks:
       - file: terraform.tfvars.json
         name: thingy
 ```
+
+# Colophon
+
+This site was built using [pandoc](https://pandoc.org/). It uses the Open Sans
+font from Google. The theme was built from scratch as a learning exercise to
+figure out [flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/)
+layouts, but is inspired by those of [mdBook](https://rust-lang.github.io/mdBook/)
+and the [Tangled documentation](https://docs.tangled.org/), the latter of which
+also served as the source of the idea to build this theme in the first place
+as well as outlining how to get pandoc to play nice. The Solarized Dark theme
+came from [bewuethr/pandoc-bash-blog](https://github.com/bewuethr/pandoc-bash-blog/)
+with some very minor modifications.

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -8,6 +8,15 @@ body {
   display: flex;
   flex-direction: row;
   height: 100vh;
+  font-weight: 400;
+}
+
+strong {
+  font-weight: 700;
+}
+
+h1, h2, h3 {
+  font-weight: 800;
 }
 
 nav a {
@@ -40,7 +49,7 @@ nav#toc ul ul li {
   padding-left: 1rem;
 }
 nav#toc > ul > li > a {
-  font-weight: bold;
+  font-weight: 800;
 }
 
 #content {
@@ -87,7 +96,7 @@ nav#sitenav > * {
   text-align: left;
 }
 .nav-prev::before {
-  font-weight: bold;
+  font-weight: 800;
   text-transform: lowercase;
   font-variant: small-caps;
   content: "Previous";
@@ -97,7 +106,7 @@ nav#sitenav > * {
   text-align: right;
 }
 .nav-next::before {
-  font-weight: bold;
+  font-weight: 800;
   text-transform: lowercase;
   font-variant: small-caps;
   content: "Next";

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,6 +1,14 @@
+:root {
+  --theme-bg: #1C2833;
+  --theme-fg: #AAB7B8;
+  --theme-nav-bg: #2E4053;
+  --theme-accent: #496684;
+  --theme-highlight: #F4F6F6;
+}
+
 body {
-  background: #1C2833;
-  color: #AAB7B8;
+  background: var(--theme-bg);
+  color: var(--theme-fg);
   font-family: "Open Sans", sans-serif;
   line-height: 1.4;
   margin: 0;
@@ -20,7 +28,7 @@ h1, h2, h3 {
 }
 
 nav a {
-  color: #AAB7B8;
+  color: var(--theme-fg);
   text-decoration: none;
 }
 nav a:hover {
@@ -29,12 +37,13 @@ nav a:hover {
 
 nav#toc {
   flex: 1 auto;
+  /* having both of these is a hack, but I'm not sure what else to do */
   min-width: 16rem;
   width: 16rem;
   overflow-y: auto;
-  background: #2E4053;
+  background: var(--theme-nav-bg);
   padding: 1rem;
-  border-right: 1px solid #496684;
+  border-right: 1px solid var(--theme-accent);
 }
 nav#toc ul {
   list-style: none outside;
@@ -67,7 +76,7 @@ main {
   flex: 1 100%;
 }
 main a {
-  color: #F4F6F6;
+  color: var(--theme-highlight);
 }
 
 pre {
@@ -75,9 +84,9 @@ pre {
 }
 
 .nav-outer {
-  border-top: 1px solid #496684;
+  border-top: 1px solid var(--theme-accent);
   flex: 1 auto;
-  background: #2E4053;
+  background: var(--theme-nav-bg);
 }
 
 nav#sitenav {
@@ -92,25 +101,23 @@ nav#sitenav > * {
   padding: 1rem;
 }
 
+.nav-prev::before, .nav-next::before {
+  font-weight: 800;
+  text-transform: lowercase;
+  font-variant: small-caps;
+  display: block;
+}
 .nav-prev {
   text-align: left;
 }
 .nav-prev::before {
-  font-weight: 800;
-  text-transform: lowercase;
-  font-variant: small-caps;
   content: "Previous";
-  display: block;
 }
 .nav-next {
   text-align: right;
 }
 .nav-next::before {
-  font-weight: 800;
-  text-transform: lowercase;
-  font-variant: small-caps;
   content: "Next";
-  display: block;
 }
 
 code {

--- a/docs/template.html
+++ b/docs/template.html
@@ -18,7 +18,7 @@ $if(description-meta)$
 $endif$
   <title>$pagetitle$</title>
   <link rel="preconnect" href="https://fonts.bunny.net">
-  <link href="https://fonts.bunny.net/css?family=open-sans:400,400i,800,800i" type="text/css" rel="stylesheet">
+  <link href="https://fonts.bunny.net/css?family=open-sans:400,400i,700,700i,800,800i" type="text/css" rel="stylesheet">
   <style type="text/css">
     $styles.css()$
   </style>


### PR DESCRIPTION
## Summary by Sourcery

Document the site’s technical details and refine typography with explicit font weights.

Enhancements:
- Set default, heading, strong text, and navigation label font weights for more granular typographic control.
- Update the Open Sans font import to include 700-weight variants used in the styles.

Documentation:
- Add a colophon section describing the site’s tooling, theme inspirations, and font/theme sources.