### PR TITLE
Sync theme back from mercury

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: extractions/setup-just@v4
         with:
-          version: 1.40.0
+          just-version: 1.40.0
 
       - name: Build with pandoc
         run: just docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,22 +27,16 @@ jobs:
       - uses: actions/configure-pages@v6.0.0
         id: pages
 
-      - name: Build with pandoc
-        uses: docker://pandoc/core:3.9
+      - uses: pandoc/actions/setup@v1
         with:
-          args: >-
-            --standalone
-            --from markdown
-            --to chunkedhtml
-            --variable toc
-            --toc-depth 2
-            --chunk-template "%i.html"
-            --template docs/template.html
-            --highlight-style docs/solarizeddark.theme
-            --output "site"
-            docs/docs.md
+          version: 3.1.11.1
 
-      - run: find site -type f
+      - uses: extractions/setup-just@v4
+        with:
+          version: 1.40.0
+
+      - name: Build with pandoc
+        run: just docs
 
       - uses: actions/upload-pages-artifact@v4.0.0
         with:

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -27,6 +27,23 @@ h1, h2, h3 {
   font-weight: 800;
 }
 
+table {
+  border-collapse: collapse;
+}
+table th {
+  background: var(--theme-nav-bg);
+}
+table tr {
+  border-bottom: 1px solid var(--theme-nav-bg);
+}
+table tr:nth-child(even) {
+  background: rgba(255,255,255,0.025);
+}
+table th, table td {
+  vertical-align: top;
+  padding: 0.25rem 0.5rem;
+}
+
 nav a {
   color: var(--theme-fg);
   text-decoration: none;

--- a/docs/template.html
+++ b/docs/template.html
@@ -23,7 +23,7 @@ $endif$
     $styles.css()$
   </style>
 $for(css)$
-  <link rel="stylesheet" href="$css$">
+  <link rel="stylesheet" href="$css$" type="text/css">
 $endfor$
 </head>
 <body>
@@ -35,7 +35,7 @@ $endfor$
 <div id="content">
 <main>
 $if(top)$
-  $-- only print title block if this is NOT the top page
+  $-- only print title block if this is NOT the top page --$
 $else$
   $if(title)$<h1>$title$</h1>$endif$
   $if(abstract)$$abstract$$endif$

--- a/justfile
+++ b/justfile
@@ -37,16 +37,16 @@ serve-docs: docs
 [group('documentation')]
 docs:
 	rm -rf site
-	pandoc docs/docs.md \
+	cd docs && pandoc docs.md \
 		--standalone \
-		--from markdown \
+		--from markdown+link_attributes \
 		--to chunkedhtml \
 		--variable toc \
 		--toc-depth 2 \
 		--chunk-template "%i.html" \
-		--template docs/template.html \
-		--highlight-style docs/solarizeddark.theme \
-		--output "site"
+		--template template.html \
+		--highlight-style solarizeddark.theme \
+		--output "../site"
 
 # run the test suite
 [group('testing')]


### PR DESCRIPTION
This pulls in the fixes I made as part of kgaughan/mercury#222, kgaughan/mercury#223, and kgaughan/mercury#224.

## Summary by Sourcery

Align documentation build and theme with the mercury project and improve docs styling and workflow.

Enhancements:
- Refine the documentation build pipeline by moving pandoc invocation into the justfile and cleaning up template comments.

Build:
- Update the docs GitHub Actions workflow to use pandoc/actions/setup with a pinned pandoc version and just for building documentation.

Documentation:
- Adjust the docs generation command and template to use the local docs directory structure, enable link attributes in markdown, and set explicit CSS link types.
- Improve docs styling by adding table styles consistent with the site theme.