### PR TITLE
Update pipelines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           go-version-file: go.mod
           check-latest: true
-          cache: true
+          cache: false
 
       - if: steps.changes.outputs.src == 'true'
         name: Run tests

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
       - uses: actions/checkout@v6.0.2
 
       - uses: actions/configure-pages@v6.0.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,12 +39,12 @@ jobs:
         with:
           go-version-file: go.mod
           check-latest: true
-          cache: true
+          cache: false
 
       - if: steps.changes.outputs.src == 'true'
         name: Lint
         uses: golangci/golangci-lint-action@v9.2.0
         with:
-          version: v2.3.0
+          version: v2.11.4
           args: --issues-exit-code=0
           only-new-issues: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           go-version-file: go.mod
           check-latest: true
-          cache: true
+          cache: false
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7.1.0


### PR DESCRIPTION
## Summary by Sourcery

Update GitHub workflows for linting, build, release, and docs pipelines.

Build:
- Disable Go toolchain caching in lint, build, and release workflows.
- Bump golangci-lint GitHub Action version used in the lint workflow.
- Update the docs workflow to use the latest checkout action version and drop the older one.