### PR TITLE
Include main in the list of branches to run govulncheck on

### DIFF
--- a/.github/workflows/vulns.yml
+++ b/.github/workflows/vulns.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - main
     tags:
       - 'v*'
   schedule:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Extend govulncheck GitHub Actions workflow to trigger on pushes to the main branch in addition to master.